### PR TITLE
Sage 9.6

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -24,7 +24,13 @@ print('Loading...')
 
 from . import common
 
-from . import addmany
+# When pyximport updates their code this warning catcher isn't needed.
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore",category=DeprecationWarning)
+    import pyximport
+    pyximport.install()
+    from . import addmany
 
 from . import examples
 from .subobjects import SubobjectZetaProcessor
@@ -73,9 +79,7 @@ def __check_sage_bugs():
     if y.series(x) != (z.series(x))(z=y):
         __SERIES_BUG = True
 
-
 __check_sage_bugs()
-
 
 class Profile:
     SAVE_MEMORY = 1
@@ -181,16 +185,16 @@ def zeta_function(type, L, objects=None, optimise_basis=False,
     if util.is_graph(L):
         if L.has_multiple_edges():
             raise ValueError('parallel edges not supported')
-
+        
     if (util.is_matrix(L) or util.is_graph(L)) and objects not in ['ask', 'cico', 'adj', 'inc']:
         raise ValueError('invalid objects specified for given input')
-
+    
     elif util.is_polynomial(L):
         # Turn a polynomial into a list of polynomials.
         L = [L]
     elif util.is_string(L):
         L = lookup(L)
-
+        
     if objects in ['poly', 'igusa']:
         proc = IgusaProcessor(*L)
     elif objects in ['subalgebras', 'ideals']:
@@ -223,7 +227,7 @@ def zeta_function(type, L, objects=None, optimise_basis=False,
             A = cico.incidence_matrix_from_multiplicities(n, mu)
         except:
             A = Matrix(L)
-
+        
         proc = IncidenceProcessor(A)
     elif objects == 'orbits':
         # NOTE: we don't currently check if L really spans a matrix Lie algebra
@@ -283,13 +287,11 @@ def do(type, L, objects='subalgebras', filename=None, save_memory=None, symbolic
             f.write(str(Z))
     return Z
 
-
 topological_zeta_function = partial(do, 'topological', strategy=Strategy.NORMAL, verbose=False)
 local_zeta_function = partial(do, 'p-adic', strategy=Strategy.NORMAL, verbose=False)
 
 top = partial(do, 'topological')
 pad = partial(do, 'p-adic')
-
 
 def check(name, objects='subalgebras', type='p-adic', **kwargs):
     L = lookup(name)
@@ -298,15 +300,15 @@ def check(name, objects='subalgebras', type='p-adic', **kwargs):
         raise RuntimeError('zeta function not contained in database')
 
     Z = do(type, L, objects, **kwargs)
-
+   
     if Z != W:
         print('Computed: ', Z)
         print('Database: ', W)
         raise RuntimeError('computed zeta function of %s differs from entry in the database' % name)
 
     print()
-    print('Algebra #%d' % lookup(name, 'id'))
-    print('Names: %s' % ', '.join(lookup(name, 'names')))
+    print('Algebra #%d' % lookup(name,'id'))
+    print('Names: %s' % ', '.join(lookup(name,'names')))
     print('Objects:', objects)
     print('Type:', type)
     print('Zeta:', Z)
@@ -345,32 +347,31 @@ if __SERIES_BUG:
 expansions. Computations of p-adic zeta functions are therefore
 unavailable. Try using a different version of Sage such as 7.4.""")
 
-
+    
 def banner():
     return """
-ZZZZZZZZZZZZZZZZZZZ                           tttt
-Z:::::::::::::::::Z                        ttt:::t
-Z:::::::::::::::::Z                        t:::::t
-Z:::ZZZZZZZZ:::::Z                         t:::::t
-ZZZZZ     Z:::::Z     eeeeeeeeeeee   ttttttt:::::ttttttt     aaaaaaaaaaaaa
-        Z:::::Z     ee::::::::::::ee t:::::::::::::::::t     a::::::::::::a
-       Z:::::Z     e::::::eeeee:::::et:::::::::::::::::t     aaaaaaaaa:::::a
-      Z:::::Z     e::::::e     e:::::tttttt:::::::tttttt              a::::a
-     Z:::::Z      e:::::::eeeee::::::e     t:::::t             aaaaaaa:::::a
-    Z:::::Z       e:::::::::::::::::e      t:::::t           aa::::::::::::a
-   Z:::::Z        e::::::eeeeeeeeeee       t:::::t          a::::aaaa::::::a
-ZZZ:::::Z     ZZZZe:::::::e                t:::::t    ttttta::::a    a:::::a
-Z::::::ZZZZZZZZ:::e::::::::e               t::::::tttt:::::a::::a    a:::::a
-Z:::::::::::::::::Ze::::::::eeeeeeee       tt::::::::::::::a:::::aaaa::::::a
+ZZZZZZZZZZZZZZZZZZZ                           tttt                           
+Z:::::::::::::::::Z                        ttt:::t                           
+Z:::::::::::::::::Z                        t:::::t                           
+Z:::ZZZZZZZZ:::::Z                         t:::::t                           
+ZZZZZ     Z:::::Z     eeeeeeeeeeee   ttttttt:::::ttttttt     aaaaaaaaaaaaa   
+        Z:::::Z     ee::::::::::::ee t:::::::::::::::::t     a::::::::::::a  
+       Z:::::Z     e::::::eeeee:::::et:::::::::::::::::t     aaaaaaaaa:::::a 
+      Z:::::Z     e::::::e     e:::::tttttt:::::::tttttt              a::::a 
+     Z:::::Z      e:::::::eeeee::::::e     t:::::t             aaaaaaa:::::a 
+    Z:::::Z       e:::::::::::::::::e      t:::::t           aa::::::::::::a 
+   Z:::::Z        e::::::eeeeeeeeeee       t:::::t          a::::aaaa::::::a 
+ZZZ:::::Z     ZZZZe:::::::e                t:::::t    ttttta::::a    a:::::a 
+Z::::::ZZZZZZZZ:::e::::::::e               t::::::tttt:::::a::::a    a:::::a 
+Z:::::::::::::::::Ze::::::::eeeeeeee       tt::::::::::::::a:::::aaaa::::::a 
 Z:::::::::::::::::Z ee:::::::::::::e         tt:::::::::::tta::::::::::aa:::a
 ZZZZZZZZZZZZZZZZZZZ   eeeeeeeeeeeeee           ttttttttttt   aaaaaaaaaa  aaaa
 
 %s
 %s
-                             by
+                             by   
                                  Tobias Rossmann
 """ % ('{:>77}'.format('VERSION ' + __version__),
        '{:>77}'.format('Released: ' + __date__))
-
 
 print(banner())


### PR DESCRIPTION
Made two changes to update Zeta to work for SageMath 9.6. 

1. Importing `addmany` caused problems since its a `.pyx` file. I added a workaround; it's not elegant. 
2. Apparently LattE's output has changed drastically. The current version that interfaces with SageMath 9.6 is LattE 1.7.6. I added a local fix in `smurf.py`, so that the data passed to the `CyclotomicRationalFunction` class is exactly the same as it was before. 

I ran some examples included in the `html` file, and I had no issues. 

One more note, my text editor seems to place spaces/tabs in places I did not edit. Sorry for that.